### PR TITLE
added the CFP form to the front page, corrected some typos, moved the de...

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,12 +28,25 @@
         <hr>
         <h1>About CfgMgmtCamp.eu</h1>
         <p>
-        CfgMgmtCamp.eu is the event for people interrested in Open Source  Confiuration management to meet eachother, CfgMgmtCamp.eu will be the event where different communities will meet and exchange ideas both internally 
+        CfgMgmtCamp.eu is the event for people interested in Open Source Configuration management to meet each other. CfgMgmtCamp.eu will be the event where different communities will meet and exchange ideas both internally 
         and within the broader community.
         </p>
-        <p>Taking place right after Fosdem in Belgium you can do 2 Open Source events in 1 trip so more value for your money. Taking place in Gent you can visit 2 Belgian cities rather than one and fall in love with Gent</p>
+        <p>Taking place right after FOSDEM in Brussels, Belgium you can do 2 Open Source events in 1 trip, so more value for your money. Taking place in Gent you can visit 2 Belgian cities, rather than one, and fall in love with Gent</p>
 
-        <p>CfgMgmtCamp.eu will have different rooms for each community,  hackspaces, trainings, workshops  and a general track with keynotes all about ConfigMangement topics.</p>
+        <p>CfgMgmtCamp.eu will have different rooms for each community,  hackspaces, trainings, workshops  and a general track with keynotes all about Configuration Management topics.</p>
+
+            <p>
+            Follow <a href="https://twitter.com/cfgmgmtcamp/">@cfgmgmtcamp</a> on Twitter to get updates!
+            </p>
+
+        <h1>Important Deadlines :</h1>
+
+<pre>
+           10/10/2013 : Call for Communities Ends 
+           15/11/2013 : Call for Community presentations Ends
+           15/12/2013 : Call for Main presentations Ends
+           3/2/2014   : CfgMgmtCamp.eu Starts
+           </pre>
 
         <h1>Call for Contributions :</h1>
 
@@ -42,51 +55,34 @@
 
         <ul>
           <li>
-          Room proposals , if you are part of a vibrant config management community we want to help you out to get to know your community and to learn from the others.  We have a limited number of rooms available to host your own 
-          sessions 
+          <strong>Room proposals</strong>: If you are part of a vibrant config management community, we want to help you out to get to know your community and to learn from others.  We have a limited number of rooms available to host your own 
+          sessions. Send new room proposals to:  
           <a href="mailto:cfp@cfgmgmtcamp.eu">cfp@cfgmtcamp.eu</a>
           </li>
-          <li>Talk proposals , we are looking for speakers for our main track, speakers about topics that are relevant for all config management tools (Application Management, Contiumous Delivery, Network Devices,
-          Distributed Systems, etc) , topics that tackle new evolutions in config management land, topics 
-          <a href="mailto:cfp@cfgmgmtcamp.eu">cfp@cfgmtcamp.eu</a>
+          <li><strong>Talk proposals</strong>: We are looking for speakers for our main track, speakers about topics that are relevant for all config management tools (Application Management, Continuous Delivery, Network Devices,
+          Distributed Systems, etc) , topics that tackle new evolutions in config management land. <a href="https://docs.google.com/spreadsheet/viewform?formkey=dHJUWEpJcGVncU92b0NNLW9TR2IyMHc6MA">Submit talk proposals for the main room</a> using the form below. We also recommend <a href="https://docs.google.com/spreadsheet/ccc?key=0Ak-xxtgink73dHJUWEpJcGVncU92b0NNLW9TR2IyMHc&usp=sharing">viewing the other talk proposals that have already been submitted</a> to avoid duplication of effort.</li>
           <li>
-          Sponsors: we are looking for sponsors of all sizes,  CfgMgmt camp is looking for a large number of sponsors for all kinds of different things.
-          The more sponsors we get the more  we can give to our attendees,  we hope to keep the event free so your contributions both big and small are welcome.
-          More Specific we are looking for  named sponsors for Breakfast , Lunch, Breaks, Social Event, Speakers Dinner and much more
-          <a href="mailto:info@cfgmgmtcamp.eu">info@cfgmtcamp.eu</a>
+          <strong>Sponsors</strong>: We are looking for sponsors of all sizes.  CfgMgmtCamp.eu is looking for a large number of sponsors for all kinds of different things.
+          The more sponsors we get the more  we can give to our attendees, and since we hope to keep the event free, your contributions both big and small are welcome.
+          More specifically we are looking for  named sponsors for Breakfast , Lunch, Breaks, Social Event, Speakers Dinner, and much more. Email
+          <a href="mailto:info@cfgmgmtcamp.eu">info@cfgmtcamp.eu</a> to sponsor.
           </li>
-          <li>A webdesigner/graphic artist : To make this site better ,  graphic/ html wizards, please send your pull requests <a href="https://github.com/cfgmgmtcamp/cfgmgmtcamp.github.io">https://github.com/cfgmgmtcamp/cfgmgmtcamp.github.io</a> 
+          <li><strong>A web designer/graphic artist</strong>: To make this site better,  graphic/ html wizards, please send your pull requests <a href="https://github.com/cfgmgmtcamp/cfgmgmtcamp.github.io">https://github.com/cfgmgmtcamp/cfgmgmtcamp.github.io</a> 
           </li>
         </ul>
 
-        <h1>Important Deadlines :</h1>
-
-<pre>
-           10/10/2013 : Call for Communities Ends 
-           15/11/2013 : Call for Community presentations Ends
-           15/12/2013 : Call for Main presentations Ends
-           3/2/2014   : CfgMgmt Camp Starts
-           </pre>
+<iframe src="https://docs.google.com/spreadsheet/embeddedform?formkey=dHJUWEpJcGVncU92b0NNLW9TR2IyMHc6MA" width="760" height="1166" frameborder="0" marginheight="0" marginwidth="0">Loading...</iframe>
 
 
         <section id="main_content">
 
             <p>
+            </p>
 
+
+            <p>
             Follow <a href="https://twitter.com/cfgmgmtcamp/">@cfgmgmtcamp</a> on Twitter to get updates!
             </p>
-            <p>
-            <br>
-            <br>
-            <br>
-            <br>
-            <br>
-            <br>
-            <br>
-            <br>
-            <br>
-            </p>
-
 
 
 <a class="twitter-timeline"  href="https://twitter.com/search?q=cfgmgmtcamp++OR+%23cfgmgmtcamp"  data-widget-id="355799269103521792">Tweets about "cfgmgmtcamp  OR #cfgmgmtcamp"</a>


### PR DESCRIPTION
...adlines section up a bit, and made some formatting changes to improve readability and consistency.

We might consider moving the CFP form to a subpage if we redesign it or when we have more content, but in an effort to keep things simple, I embedded it into the home page for now. I reorganized a few things so that the CFP form would be near the bottom (just above Twitter) to avoid pushing things like the deadlines too far down.
