### PR TITLE
Add a Chef Community Room description and CFP

### DIFF
--- a/Chef.html
+++ b/Chef.html
@@ -51,7 +51,30 @@
 
       <div class="inner">
         <section id="about">
-          <h1 id="about">Chef Community</h1>
+          <h1 id="about">Chef Community Room</h1>
+
+          <p>
+            <a href="http://www.opscode.com/chef/">Chef</a> is an automation platform that transforms infrastructure into code. Stop thinking in terms of physical and virtual servers. With Chef, your real asset is the code that brings those servers and the services they provide to life. An automated infrastructure can accelerate your time to market, help you manage scale and complexity, and safeguard your systems.
+          </p>
+
+          <p>
+            Whether your network is in the cloud, on-site, or a hybrid, Chef can automate how you configure, deploy and scale your servers and applications, whether you manage 5 servers, 5,000 servers or 500,000 servers. It's no wonder that Chef has been chosen by companies like <a href="http://www.opscode.com/customers/facebook/">Facebook</a> and <a href="http://www.opscode.com/customers/schuberg-philis/">Schuberg Philis</a> for mission-critical challenges.
+          </p>
+
+          <p>
+            Join us in the Chef Community Room as we provide some introductory talks on Monday and allow for some more intermediate-to-advanced topics on Tuesday along with some time for open spaces and hacking.
+          </p>
+
+          <p>
+            What would you like to discuss or present in the Chef Community Room?  Please submit a talk proposal below.  All proposals are due by <a href="http://www.timeanddate.com/worldclock/fixedtime.html?msg=Chef+Community+Room+CFP+Deadline&iso=20131115T2359">11:59 UTC on November 15, 2013</a>.
+          </p>
+
+          <iframe src="https://docs.google.com/forms/d/1r32JFwdDQPQ0sD74Ap5xJN4BP5GUxV90Xk-1Waf12Ag/viewform?embedded=true" width="760" height="500" frameborder="0" marginheight="0" marginwidth="0">Loading...</iframe>
+
+          <p>
+            We look forward to seeing you in Gent for the Config Management Camp.  Please also consider submitting your talk as part of the <a href="https://penta.fosdem.org/submission/">Configuration Management devroom for FOSDEM</a>, too.
+          </p>
+      </div>
     </div>
 	
   </body>

--- a/index.html
+++ b/index.html
@@ -59,7 +59,7 @@
           <p>Taking place right after FOSDEM, Belgium you can do 2 Open Source events in 1 trip, so more value for your money. Taking place in Gent you can visit 2 Belgian cities, rather than one, and fall in love with Gent</p>
 
           <p>CfgMgmtCamp.eu will have different rooms for each community,  hackspaces, trainings, workshops  and a general track with keynotes all about Configuration Management topics.</p>
-          <p>Today we have commitment from the  Ansible, Cfengine & Rudder, Chef, Juju, <a href="Puppet.html">Puppet</a> and SaltStack communities. So there will be plenty of topics to choose from. These communities will be providing more details about how to participate in their portion of the event at the links above.</p>
+          <p>Today we have commitment from the  Ansible, Cfengine & Rudder, <a href="Chef.html">Chef</a>, Juju, <a href="Puppet.html">Puppet</a> and SaltStack communities. So there will be plenty of topics to choose from. These communities will be providing more details about how to participate in their portion of the event at the links above.</p>
           <p>
           We aim at keeping the event free, but will be asking people to register themselves and specify which parallel tracks they are interested in, this in order to try to accommodate the respective communities in the right sized rooms.
           <p>


### PR DESCRIPTION
- Link to the Chef page from the home page
- Add a description of the Che community room
- Embed the Google form for collecting Chef proposals
