### PR TITLE
Extended CFP deadline. Cleaned up sponsor logos.

### DIFF
--- a/fosdem.html
+++ b/fosdem.html
@@ -66,7 +66,7 @@ real world use cases</li>
   <h1>Devroom Deadlines</h1>
 <p>Since the Configuration Management Devroom is held at the FOSDEM conference, it also follows the date guideline of FOSDEM. Here's an overview of the most important dates:</p>
   <ul class="dates">
-    <li><span>1/12/2013</span> : Devroom CFP Ends</li>
+    <li><span>8/12/2013</span> : Devroom CFP Ends</li>
     <li><span>13/12/2013</span>   : Speakers notified</li>
     <li><span>30/12/2013</span>   : Agenda published on FOSDEM site</li>
     <li><span>1/2/2014</span> : Configuration Management Devroom starts</li>

--- a/index.html
+++ b/index.html
@@ -80,7 +80,7 @@
         </section>
 
 
-        <!-- sponsors: Add all logos at height="200" to keep things lined up  -->
+        <!-- sponsors: Add platinum logos at height="250", gold logos at height="200", silver logos at height="100" to keep things lined up  -->
         <section id="sponsors">
           <h1>Sponsors</h1>
              <p>Thank you to our existing sponsors!</p>
@@ -88,11 +88,12 @@
           <h2>Platinum</h2>
 -->
           <h2>Gold</h2>
-             <p><a href="http://puppetlabs.com"><img src="images/puppetlabs-logo.jpg" height="200"></a></p>
-             <p><a href="http://http://www.hogent.be/"><img src="images/FBO-EN.png" height="200"></a></p>
+             <p><a href="http://puppetlabs.com"><img src="images/puppetlabs-logo.jpg" height="200"style="PADDING-LEFT: 15px"></a>
+                <a href="http://http://www.hogent.be/"><img src="images/FBO-EN.png" height="200" style="PADDING-LEFT: 15px"></a>
+             </p>
 
           <h2>Silver</h2>
-             <p><a href="http://wwww.atcomputing.nl"><img src="ATlogo_cfgmgmtcamp.png" height="200"></a></p>
+             <p><a href="http://wwww.atcomputing.nl"><img src="images/ATlogo_cfgmgmtcamp.png" height="100" style="PADDING-LEFT: 15px"></a></p>
 
 <!--
           <h2>Bronze</h2>


### PR DESCRIPTION
Fixed atcomputing logo (img was pointing to the wrong file location. Adjusted img params to make things line up better. Extended fosdem devroom deadline to Dec 8.
