### PR TITLE
Lunch break and logo size consistency

### DIFF
--- a/index.html
+++ b/index.html
@@ -103,7 +103,7 @@
 
           <h2>Silver</h2>
              <p><a href="http://wwww.atcomputing.nl"><img src="images/ATlogo_cfgmgmtcamp.png" height="100" style="PADDING-LEFT: 15px"></a></p>
-             <p><a href="http://cfengine.com/"><img src="images/cfengine-logo.png" height="200" style="PADDING-LEFT: 15px"></a></p>
+             <p><a href="http://cfengine.com/"><img src="images/cfengine-logo.png" height="100" style="PADDING-LEFT: 15px"></a></p>
 
 <!--
           <h2>Bronze</h2>
@@ -180,12 +180,19 @@
               <tr><td>14:00 - 17:00</td><td colspan=3>Salt Community Breakout</td></tr>
               <tr />            
               <tr><td colspan=4><br /><strong>Tuesday  February 4th , 2014</strong></td> </tr>
-              <tr><td>9:30 - 17:00</td><td colspan=3>Ansible Community Breakout</td></tr>
-              <tr><td>9:30 - 17:00</td><td colspan=3>CFEngine/Rudder Community Breakout</td></tr>
-              <tr><td>9:30 - 17:00</td><td colspan=3>Chef Community Breakout</td></tr>
-              <tr><td>9:30 - 17:00</td><td colspan=3>Juju Community Breakout</td></tr>
-              <tr><td>9:30 - 17:00</td><td colspan=3>Puppet Community Breakout</td></tr>
-              <tr><td>9:30 - 17:00</td><td colspan=3>Salt Community Breakout</td></tr>
+              <tr><td>9:30 - 12:40</td><td colspan=3>Ansible Community Breakout</td></tr>
+              <tr><td>9:30 - 12:40</td><td colspan=3>CFEngine/Rudder Community Breakout</td></tr>
+              <tr><td>9:30 - 12:40</td><td colspan=3>Chef Community Breakout</td></tr>
+              <tr><td>9:30 - 12:40</td><td colspan=3>Juju Community Breakout</td></tr>
+              <tr><td>9:30 - 12:40</td><td colspan=3>Puppet Community Breakout</td></tr>
+              <tr><td>9:30 - 12:40</td><td colspan=3>Salt Community Breakout</td></tr>
+              <tr><td>12:40 - 14:00</td><td colspan=3>Lunch</td></tr>
+              <tr><td>14:00 - 17:00</td><td colspan=3>Ansible Community Breakout</td></tr>
+              <tr><td>14:00 - 17:00</td><td colspan=3>CFEngine/Rudder Community Breakout</td></tr>
+              <tr><td>14:00 - 17:00</td><td colspan=3>Chef Community Breakout</td></tr>
+              <tr><td>14:00 - 17:00</td><td colspan=3>Juju Community Breakout</td></tr>
+              <tr><td>14:00 - 17:00</td><td colspan=3>Puppet Community Breakout</td></tr>
+              <tr><td>14:00 - 17:00</td><td colspan=3>Salt Community Breakout</td></tr>
             </tbody>
           </table>
           <br />


### PR DESCRIPTION
Added lunch break to second day agenda to make sure that all rooms have the same lunch time (for catering purposes). Changed the size of the CFEngine logo to be the same size as the other silver sponsor.
