### PR TITLE
Remove Chef CFP, update links

### DIFF
--- a/Chef.html
+++ b/Chef.html
@@ -54,11 +54,11 @@
           <h1 id="about">Chef Community Room</h1>
 
           <p>
-            <a href="http://www.opscode.com/chef/">Chef</a> is an automation platform that transforms infrastructure into code. Stop thinking in terms of physical and virtual servers. With Chef, your real asset is the code that brings those servers and the services they provide to life. An automated infrastructure can accelerate your time to market, help you manage scale and complexity, and safeguard your systems.
+            <a href="http://www.getchef.com/chef/">Chef</a> is an automation platform that transforms infrastructure into code. Stop thinking in terms of physical and virtual servers. With Chef, your real asset is the code that brings those servers and the services they provide to life. An automated infrastructure can accelerate your time to market, help you manage scale and complexity, and safeguard your systems.
           </p>
 
           <p>
-            Whether your network is in the cloud, on-site, or a hybrid, Chef can automate how you configure, deploy and scale your servers and applications, whether you manage 5 servers, 5,000 servers or 500,000 servers. It's no wonder that Chef has been chosen by companies like <a href="http://www.opscode.com/customers/facebook/">Facebook</a> and <a href="http://www.opscode.com/customers/schuberg-philis/">Schuberg Philis</a> for mission-critical challenges.
+            Whether your network is in the cloud, on-site, or a hybrid, Chef can automate how you configure, deploy and scale your servers and applications, whether you manage 5 servers, 5,000 servers or 500,000 servers. It's no wonder that Chef has been chosen by companies like <a href="http://www.getchef.com/customers/facebook/">Facebook</a> and <a href="http://www.getchef.com/customers/schuberg-philis/">Schuberg Philis</a> for mission-critical challenges.
           </p>
 
           <p>
@@ -66,16 +66,9 @@
           </p>
 
           <p>
-            What would you like to discuss or present in the Chef Community Room?  Please submit a talk proposal below.  All proposals are due by <a href="http://www.timeanddate.com/worldclock/fixedtime.html?msg=Chef+Community+Room+CFP+Deadline&iso=20131215T2359">11:59 UTC on December 15, 2013</a>.
-          </p>
-
-          <iframe src="https://docs.google.com/forms/d/1r32JFwdDQPQ0sD74Ap5xJN4BP5GUxV90Xk-1Waf12Ag/viewform?embedded=true" width="760" height="500" frameborder="0" marginheight="0" marginwidth="0">Loading...</iframe>
-
-          <p>
-            We look forward to seeing you in Gent for the Config Management Camp.  Please also consider submitting your talk as part of the <a href="/fosdem.html">Configuration Management devroom for FOSDEM</a>, too.
+            We look forward to seeing you in Gent for the Config Management Camp.
           </p>
       </div>
-    </div>
-	
+    </div>	
   </body>
 </html>


### PR DESCRIPTION
- remove the CFP for Chef talks
- use getchef.com instead of opscode.com
