### PR TITLE
Link schedule to community rooms

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,9 +54,9 @@
         <section id="Keynote">
           <h1>Keynotes and First Sessions</h1>
           <p>CfgMgmtCamp.eu is proud to announce it's 3 Opening Keynotes.
-          In historical order,  Mark Burgess, who brought us CFEngine, Luke Kanies, who brought us Puppet and Adam Jacob who brought us Chef.
+          In historical order,  <a href="MarkBurgess.html">Mark Burgess</a>, who brought us CFEngine, <a href="LukeKanies.html">Luke Kanies</a>, who brought us Puppet, and <a href="AdamJacob.html">Adam Jacob</a> who brought us Chef.
           </p>
-          <p>We are now also announcing the first batch of confirmed talks !</p>
+          <p>We are now also announcing the first batch of confirmed talks!</p>
 
           <ul>
           <li>James Turnbull about <a href="JamesTurnbull.html">Introduction to Docker</a>
@@ -178,7 +178,7 @@
 
         Obviously 1 and 2 February you will all be at <a href="http://fosdem.org/">Fosdem</a>
 
-        And if you still haven't enough , stick around in Ghent for <a href="http://community.redhat.com/blog/2013/12/announcing-infrastructure-next/">Infrastructure.Next</a> organised by the RedHat Community.
+        And if you still haven't enough, stick around in Ghent for <a href="http://community.redhat.com/blog/2013/12/announcing-infrastructure-next/">Infrastructure.Next</a> organised by the RedHat Community.
         </section>
 
       


### PR DESCRIPTION
- Link main schedule to individual community rooms.
- Link Mark, Luke, and Adam in the opening paragraph to their talks.
- A few other minor spacing updates
