### PR TITLE
Puppet Contributor Summit schedule sync (partly synced)

### DIFF
--- a/Puppet.html
+++ b/Puppet.html
@@ -66,23 +66,26 @@
                 <p><strong>February 3</strong></p>
                 <ul>
                    <li>09:30 - 14:00: CfgMgmtCamp.eu keynotes and lunch</li>
-                   <li>14:00 - 15:15: State of where we are as a project and a community (Eric Sorenson / Ryan Coleman)</li>
-                   <li>15:15 - 16:00: Low friction contribution from bug report to shipping (Deepak)</li>
-                   <li>16:00 - 17:30: Open discussion about improving community process</li>
-                   <li>17:30 - 18:00: Community recognition (Dawn)</li>
+                   <li>14:00 - 15:20: State of where we are as a project and a community (Eric Sorenson / Ryan Coleman)</li>
+                   <li>15:20 - 15:40: Break</li>
+                   <li>15:40 - 16:20: Low friction contribution from bug report to shipping (Deepak)</li>
+                   <li>16:20 - 17:40: Open discussion about improving community process</li>
+                   <li>17:40 - 18:00: Community recognition (Dawn)</li>
                 </ul> 
                 <p><strong>February 4</strong></p>
                 <ul>
                    <li>09:30 - 10:30: Q&A with Luke Kanies</li>
                    <li>10:30 - 11:00: Cron (Felix Frank)</li>
-                   <li>11:00 - 11:30: Puppetboard (Daenney)</li>
-                   <li>11:30 - 12:00: Writing your own augeasproviders (Dominic Cleal)</li>
-                   <li>12:00 - 12:30: Kafo - the framework for creating shiny installers based on Puppet (Marek Hulán)</li>
-                   <li>12:40 - 14:00: Lunch</li>
+                   <li>11:00 - 11:20: Break
+                   <li>11:20 - 11:50: Puppetboard (Daenney)</li>
+                   <li>11:50 - 12:20: Writing your own augeasproviders (Dominic Cleal)</li>
+                   <li>12:20 - 12:50: Kafo - the framework for creating shiny installers based on Puppet (Marek Hulán)</li>
+                   <li>13:00 - 14:00: Lunch</li>
                    <li>14:00 - 14:30: Testing with Beaker (Ryan Coleman)</li>
                    <li>14:30 - 15:00: TDD with rspec (Johan De Wit + Jan Vansteenkiste)</li>
                    <li>15:00 - 15:30: Contributions to Puppet (Erik Dalen)</li>
-                   <li>15:30 - 17:00: Hacking time - work on your favorite Puppet project together</li>
+                   <li>15:30 - 15:40: Break</li>
+                   <li>15:40 - 17:00: Hacking time - work on your favorite Puppet project together</li>
                  </ul>
 
                 <p>You can contact Dawn Foster for questions about this event. Her email address is dawn@ the Puppet Labs domain.</p> 


### PR DESCRIPTION
Minor tweaks to Puppet Contributor Summit schedule to sync up with as much of the rest of the schedule as possible. Lunches / breaks on both days is in sync. Monday's agenda is in sync with the others. Tuesday wasn't possible to sync up beyond lunch / break due to my 30 minute format.
