### PR TITLE
Correct link to JorgeSalameroSanz

### DIFF
--- a/schedule/index.html
+++ b/schedule/index.html
@@ -106,7 +106,7 @@
             <li>14:40 - <a href="speakers/StuartPreston.html">Cross-platform Infrastructure testing with Microsoft Azure, Test Kitchen and InSpec - Stuart Preston</a></li>
             <li>15:20 - BREAK</li>
             <li>15:40 - <a href="speakers/MattBruzek.html">Juju Charm Testing and Debugging - Matt Bruzek</a></li>
-            <li>16:20 - <a href="speakers/JorgeSalamerosanz.html">War Games - flight training for DevOps - Jorge Salamero</a></li>
+            <li>16:20 - <a href="speakers/JorgeSalameroSanz.html">War Games - flight training for DevOps - Jorge Salamero</a></li>
           </ul>
           </li>
 


### PR DESCRIPTION
Correct capitalisation of Jorge Salamero Sanz speaker link. This caused 404 when selecting the talk from schedule/index.html page