### PR TITLE
Add link to Lanyrd schedule and mobile apps

### DIFF
--- a/schedule/index.html
+++ b/schedule/index.html
@@ -55,6 +55,11 @@
 
         The schedule includes a <a href='#main'>main track</a>, <a href='#general'>general sessions</a>, and <a href='#communities'>community rooms</a> for <a href='#ansible'>Ansible</a>, <a href='#chef'>Chef</a>, <a href='#cfengine-rudder'>CFEngine/Rudder</a>, <a href='#foreman'>Foreman</a>, <a href='#juju'>Juju</a>, <a href='#puppet'>Puppet</a>, and <a href='#salt'>Salt</a>.
 
+        <br/>
+        <br/>
+
+        This full schedule is also <a href="http://lanyrd.com/2016/cfgmgmtcamp/schedule/">available on Lanyrd</a> where you can make up your own personalised schedule, using the web site or their mobile application (<a href="https://play.google.com/store/apps/details?id=com.lanyrd.lanyrd">Android (Play Store)</a> | <a href="http://itunes.apple.com/us/app/lanyrd/id467652813">iOS (App Store)</a> | <a href="https://m.lanyrd.com/">Mobile web site</a>).
+
         <a name='main'></a>
         <h1>Main Track</h1>
         <h3>D.AUD</h3>


### PR DESCRIPTION
This adds a link to the top of the schedule page to our schedule on Lanyrd. I didn't see any existing links to Lanyrd, which is a pity since "we" (aka Kris) have gone to so much effort to have the schedule up there.

The mobile apps are also a great convenience to attendees to plan their schedule.