### PR TITLE
Add Fringe page to site

### DIFF
--- a/fringe.html
+++ b/fringe.html
@@ -1,92 +1,74 @@
 <!DOCTYPE html>
 <html>
-<head>
-  <meta charset='utf-8'>
-  <meta http-equiv="X-UA-Compatible" content="chrome=1">
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <meta name="MobileOptimized" content="width" />
-  <meta name="HandheldFriendly" content="true" />
-  <meta name="apple-mobile-web-app-capable" content="yes" />
-  <link href='https://fonts.googleapis.com/css?family=Chivo:900' rel='stylesheet' type='text/css'>
-  <link rel="stylesheet" href="http://maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css">
-  <link rel="stylesheet" type="text/css" href="http://cfgmgmtcamp.eu/stylesheets/stylesheet.css" media="screen" />
-  <link rel="stylesheet" type="text/css" href="http://cfgmgmtcamp.eu/stylesheets/pygment_trac.css" media="screen" />
-  <link rel="stylesheet" type="text/css" href="http://cfgmgmtcamp.eu/stylesheets/print.css" media="print" />
-  <link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.6.4/leaflet.css" />
-  <link rel="shortcut icon" href="http://cfgmgmtcamp.eu/favicon.ico">
-  <!--[if lte IE 8]>
-  <link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.6.4/leaflet.ie.css" />
-  <![endif]-->
-  <!--[if lt IE 9]>
-  <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
-  <![endif]-->
-  <script src="http://cdn.leafletjs.com/leaflet-0.6.4/leaflet.js"></script>
-  <title>Config Management Camp 2016, Gent, Fringe</title>
-</head>
+  <head>
+    <meta charset='utf-8'>
+    <meta http-equiv="X-UA-Compatible" content="chrome=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="MobileOptimized" content="width" />
+    <meta name="HandheldFriendly" content="true" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <link href='https://fonts.googleapis.com/css?family=Chivo:900' rel='stylesheet' type='text/css'>
+    <link rel="stylesheet" type="text/css" href="stylesheets/stylesheet.css" media="screen" />
+    <link rel="stylesheet" type="text/css" href="stylesheets/pygment_trac.css" media="screen" />
+    <link rel="stylesheet" type="text/css" href="stylesheets/print.css" media="print" />
+    <link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.6.4/leaflet.css" />
+    <link rel="shortcut icon" href="favicon.ico">
+    <!--[if lte IE 8]>
+       <link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.6.4/leaflet.ie.css" />
+    <![endif]-->
+    <!--[if lt IE 9]>
+    <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
+    <![endif]-->
+    <script src="http://cdn.leafletjs.com/leaflet-0.6.4/leaflet.js"></script>
+    <title>Config Management Camp Gent  2017</title>
+  </head>
 
-<body>
+  <body>
     <nav>
       <a href="#" id="menu-icon">&#x2261;</a>
       <ul>
-      <li><a href="#about">About</a></li>
-      <li><A href="#news">News</a></li>
-      <li><a href="#registration">Registration</a></li>
-      <li><a href="#sponsors">Sponsors</a></li>
-      <li><a href="#route">Location</a></li>
-      <li><a href="#contributions">CFP</a></li>
-      <li><a href="code_of_conduct.html">Code of Conduct</a></li>
-      <li><a href="2014/">2014</a></li>
-      <li><a href="2015/">2015</a></li>
+      <li><a href="/#about">About</a></li>
+      <li><A href="/#news">News</a></li>
+      <li><a href="/#registration">Registration</a></li>
+      <li><a href="/#sponsors">Sponsors</a></li>
+      <li><a href="/#route">Location</a></li>
+      <li><a href="/#contributions">CFP</a></li>
+      <li><a href="/code_of_conduct.html">Code of Conduct</a></li>
+      <li><a href="/past_events.html">Past Events</a></li>
       </ul>
     </nav>
 
-  <div id="container">
-    <header>
-      <div class="inner">
-        <h1>#cfgmgmtcamp</h1>
-        <div class="camp-info">
-          <h2><strong>1</strong> and <strong>2</strong> February 2016</h2>
-          <h2>Gent, Belgium </h2>
+    <div id="container">
+      <header>
+        <div class="inner">
+          <h1>Config Management Camp</h1>
+          <div class="camp-info">
+            <h2>CfgMgmtCamp Fringe</h2>
+            <h2><strong>8 February 2017</strong></h2>
+          </div>
         </div>
-      </div>
-    </header>
+      </header>
+
 
 
     <div class="inner">
       <section id="content">
         <h1>Fringe</h1>
 
-        <p>In tradition with other <a href="https://fosdem.org/2016/fringe/">FOSS events</a> there are a couple of events on the "Fringe" of Config Management Camp
+        <p>In tradition with other <a href="https://fosdem.org/2017/fringe/">FOSS events</a> there are a couple of events on the "Fringe" of Config Management Camp
         </p>
 
         <p>
         In the same venue as Config Management Camp we are hosting:
 
-        <h2>Puppet Contributors Summit</h2>
-
-        <p>
-        Puppet Labs is holding our third Puppet Contributors Summit in Ghent, Belgium on February 3, 2016, the day after Config Management Camp.
-        This event is for both existing and new contributors to Puppet, related projects, and modules, and we would love to see the following people attend the Contributors Summit!
-        <ul><li>People who submit pull requests and contribute code to our projects</li>
-        <li>Community members working on related projects</li>
-        <li>People who contribute to Puppet Labs modules or contribute their own modules to the Puppet Forge</li>
-        <li>Key community members who answer a lot of questions about using Puppet</li>
-        <li>Long-time Puppet users who are interested in doing more</li>
-      </ul>
-         Learn more about the Puppet Contributor Summit and other contributor events.
-         All attendees at Puppet Labs events (speakers and participants) should adhere to our Community Guidelines and Event Code of Conduct.
-         Register: <a href="http://puppet-contributor-summit-ghent-2016.eventbrite.com">Here</a>
-
-        </p>
-
         <h2>Foreman Construction Day</h2>
+
         <p>
-        Foreman will be holding the first Foreman Construction Day on
-        Wednesday 3rd February 2016, which is the day after Config Management
+        Foreman will be holding it's second Foreman Construction Day on
+        Wednesday 8th February 2017, which is the day after Config Management
         Camp.
 
-        </p>
-        <p>
+        </p> <p>
         The aim is to build upon on the previous 2-4 days of talks and
         discussions, and put it to use! We're open to all members of our
         community, such as
@@ -104,17 +86,28 @@
         see you there!
 
 
-        <p>
-        Register: <a href="https://www.eventbrite.com/e/foreman-construction-day-registration-19911909056">Here</a>
+        </p> <p>
+        Register: <a href="http://foreman-construction-day-2017.eventbrite.com/">On Eventbrite</a>
         </p>
-        <h2>Juju Charmer Summit</h2>
+
+        <h2>Puppet Contributors Summit</h2>
+
         <p>
-        The Juju Charmer Summit is a special three day event co-located within cfgmgmtcamp in Gent, Belgium. Enjoy two days of Juju sessions as well as sessions around Puppet, Chef, Ansible, Foreman, and other tools. The third day is a Juju deep dive, where we will go into charm design, building charms with layers, and code review. We recommend attending the full three days, two days of cfgmgmtcamp, and one day of the Charmer Summit if you're looking for the full educational experience.
-        </p><p>
-        The Summit concentrates on charm design and authorship of charms. If you're interested in getting your code to end users in the cloud, then this is the event for you. We have workshop sessions, presentations, and most importantly, peer programming time with charm experts.
-        </p><p>
-        Register <a href="http://summit.juju.solutions/">Here</a>
+        Puppet Labs is holding our fourth Puppet Contributors Summit in Ghent, Belgium on February 8, 2017, the day after Config Management Camp.
+        This event is for both existing and new contributors to Puppet, related projects, and modules, and we would love to see the following people attend the Contributors Summit!
+        <ul><li>People who submit pull requests and contribute code to our projects</li>
+        <li>Community members working on related projects</li>
+        <li>People who contribute to Puppet Labs modules or contribute their own modules to the Puppet Forge</li>
+        <li>Key community members who answer a lot of questions about using Puppet</li>
+        <li>Long-time Puppet users who are interested in doing more</li>
+      </ul>
+         Learn more about the Puppet Contributor Summit and other contributor events.
+         All attendees at Puppet Labs events (speakers and participants) should adhere to our Community Guidelines and Event Code of Conduct.
+         Register: TBA
+         <!-- Register: <a href="http://puppet-contributor-summit-ghent-2017.eventbrite.com">Here</a> -->
+
         </p>
+
       </section>
     </div>
   </div>

--- a/index.html
+++ b/index.html
@@ -46,7 +46,7 @@
         <div class="inner">
           <h1>Config Management Camp</h1>
           <div class="camp-info">
-            <h2><strong>6 and 7 february 2017</strong></h2>
+            <h2><strong>6 and 7 February 2017</strong></h2>
             <h2>Gent , Belgium</h2>
           </div>
         </div>
@@ -66,8 +66,10 @@
 
             </p> <p>
       CfgMgmtCamp.eu will have different rooms for each community, hackspaces, trainings, workshops and a general track with keynotes all about Configuration Management topics.</p>
-    </section>
 
+            </p> <p>
+      CfgMgmtCamp.eu are also happy to welcome back the fringe events on Wednesday, including the traditional Puppet Contributors summit, and another Foreman Construction day. Take a look at our <a href="fringe.html">Fringe</a> page for more info.</p>
+    </section>
 
       <section id="news">
 

--- a/index.html
+++ b/index.html
@@ -181,7 +181,8 @@
           <h1>Call for Contributions/Presentations</h1>
 
       <b>
-         <p>We have just opened the <a href="https://goo.gl/forms/ApkVFYZvLokmBmjD3">CFP</a> for Config Management Camp Gent 2017☐·
+         <p>The CFP for Config Management Camp 2017 in Gent is now Closed, we received 120+ proposals and we are now busy evaluating them all.
+         The CFP for the Fosdem Configuration Management Devroom is also closed.</p>
 
       </b>
       </p>


### PR DESCRIPTION
Mostly a cut'n'paste of last year, plus I fixed the nav links (which I don't think ever worked from the fringe page, as they were relative) and altered the header slightly to make the change of page clearer.

I've kept the Puppet Contributor section as I hear Meg is planning something - but we should probably get a registration link from them before merging. I've removed JuJu for now since I've not heard anything about that.
