### PR TITLE
Fix a broken link, move an anchor

### DIFF
--- a/fringe.html
+++ b/fringe.html
@@ -129,6 +129,7 @@
               Key community members who answer a lot of questions about using
               Puppet
             </li>
+            <a name="habitat"></a>
             <li>
               Long-time Puppet users who are interested in doing more
             </li>
@@ -136,7 +137,6 @@
         </p>
 
         <p>
-          <a name="habitat"></a>
           Learn more about the Puppet Contributor Summit and other contributor
           events.  All attendees at Puppet Labs events (speakers and
           participants) should adhere to our Community Guidelines and Event Code

--- a/schedule/containers/ian-henry.html
+++ b/schedule/containers/ian-henry.html
@@ -88,7 +88,7 @@
         <h3>Wednesday, February 8, 10:00 - 16:30 - B3.019</h3>
 
         <p>
-          Join us on Wednesday for a <a href="../fringe.html#habitat">Habitat
+          Join us on Wednesday for a <a href="../../fringe.html#habitat">Habitat
           workshop</a>.
         </p>
 


### PR DESCRIPTION
* Fix link to Habitat Workshop from Ian Henry's page
* Move the anchor for habitat on the Fringe page

Signed-off-by: Nathen Harvey <nharvey@chef.io>