### PR TITLE
Moves the anchor tags around on the schedule page

### DIFF
--- a/schedule/index.html
+++ b/schedule/index.html
@@ -61,9 +61,9 @@
           <a href='#communities'>community rooms</a> for
           <a href='#ansible'>Ansible</a>, <a href='#cfengine'>CFEngine</a>,
           <a href='#chef'>Chef</a>, <a href='#foreman'>Foreman</a>,
-          <a href='#juju'>Juju</a>, <a href='#mgmt'>mgmt</a>,<a href='#kube'>kubernetes</a>,
-          <a href='#puppet'>Puppet</a>, <a href='#rudder'>Rudder</a>, and
-          <a href='#salt'>Salt</a>.
+          <a href='#juju'>Juju</a>, <a href='#kube'>kubernetes</a>,
+          <a href='#mgmt'>mgmt</a>, <a href='#puppet'>Puppet</a>,
+          <a href='#rudder'>Rudder</a>, and <a href='#salt'>Salt</a>.
         </p>
         <p>
           There are also a number of <a href="#fringe">Fringe events</a> being
@@ -161,16 +161,16 @@
           <strong>Tuesday, February 7</strong>
         </p>
         <ul>
+          <a name="communities"></a>
           <li>11:00 - Monitoring as Code with Icinga 2 - Blerim Sheqa</li>
           <li>11:40 - Orchastrating a Platform with BOSH - Justin Carter</li>
+          <a name="ansible"></a>
           <li>12:20 - Centralised Logging without the blood sweat and tears - Paul Stack</li>
         </ul>
 
       </ul>
         <h1>Community Rooms</h1>
-          <a name="communities"></a>
 
-          <a name="ansible"></a>
         <h2>Ansible</h2>
         <h3>B1.017</h3>
         <ul>
@@ -188,6 +188,7 @@
           <li>Tuesday, February 7
             <ul>
               <li>14:00 - Provisioning, Ansible, Foreman, Bare Metal - Toshaan Bharvani </li>
+              <a name="cfengine"></a>
               <li>14:40 - Orchestration, Ansible, Networking - Attilla de Groot</li>
               <li>15:20 - Break</li>
               <li>15:40 - Introduction to running tests and deployments with GitLab CI and Ansible - Joeri Poese</li>
@@ -195,7 +196,6 @@
           </li>
         </ul>
 
-              <a name="cfengine"></a>
         <h2>CFEngine</h2>
         <h3>B3.036</h3>
         <ul>
@@ -210,6 +210,7 @@
           <li>Tuesday, February 7
             <ul>
               <li>14:00 - How to use the augments file (def.json) Bas van der Vlies </li>
+              <a name="chef"></a>
               <li>14:40 - Merging Technologies , ideas on using CFengine with cloud and container technologies, Jurica Borozan</li>
               <li>15:20 - Break</li>
               <li>15:40 - CFEngine simplified with EFL - Neil Watson</li>
@@ -218,7 +219,6 @@
         </ul>
 
         <h2>Chef</h2>
-              <a name="chef"></a>
         <h3>B3.019</h3>
         <p>
           The following talks will happen in the Chef Community room (B3.019).
@@ -240,6 +240,7 @@
           <li>Tuesday, February 7
             <ul>
               <li>14:00 - <a href="chef/michael-goetz.html">Shared Services is Not a Field of Dreams</a> - Michael Goetz</li>
+              <a name="foreman"></a>
               <li>14:40 - <a href="chef/brian-oconnell.html">CI/CD Workflows at Enterprise Sports Scale</a> - Brian O'Connell</li>
               <li>15:20 - Break</li>
               <li>15:40 - <a href="chef/marek-hulan.html">How to get the most of Foreman and Chef</a> - Marek Hulán</li>
@@ -248,7 +249,6 @@
         </ul>
 
         <h2>Foreman</h2>
-              <a name="foreman"></a>
         <h3>B2.015</h3>
         <ul>
           <li>
@@ -260,7 +260,7 @@
               <li>15:20 - Break</li>
               <li>15:40 - Foreman templating engine - best practises and future - Mark Hulan</li>
               <li>16:20 - Building Robust & Scalable Environments with Foreman + Katello - Rich Jerrido (TBC)</li>
-              <li>17:00 - Orchestrating tasks accross multiple hosts with the Foreman - Tomáš Strachota 
+              <li>17:00 - Orchestrating tasks accross multiple hosts with the Foreman - Tomáš Strachota
               </li>
             </ul>
           </li>
@@ -270,13 +270,13 @@
               <li>14:20 - Getting Your Issues Fixed in Foreman - Tomer Brisker</li>
               <li>14:40 - Puppet 4 support in Foreman - Michaell Moll </li>
               <li>15:20 - Break</li>
+              <a name="juju"></a>
               <li>15:40 - Drop OS images on bare-metal - Lukas Zapletal</li>
               <li>16:00 - Chickens and eggs: finding and resolving inter-node dependency issues with puppet. Simon Peeters</li>
             </ul>
           </li>
         </ul>
 
-              <a name="juju"></a>
         <h2>Juju</h2>
         (Most of the Juju Track still has to be confirmed)
         <h3>B4.039</h3>
@@ -296,6 +296,7 @@
             <ul>
               <li>14:00 - Konstantinos Tsakalozos - Sharing Operational Knowledge & Secrets
               </li>
+              <a name="kube"></a>
               <li>14:40 - Charles Butler - Operating Etcd at scale without losing sleep
               </li>
               <li>15:20 - Break</li>
@@ -305,13 +306,25 @@
           </li>
         </ul>
 
+        <h2>Kubernetes</h2>
+        <a name="mgmt"></a>
+        <h3>B3.039</h3>
+        <ul>
+          <li>
+            Tuesday, February 7
+            <ul>
+              <li>14:00 - Kubernetes Hackathon and Lightning Talks </li>
+            </ul>
+          </li>
+
+
         <h2>mgmt</h2>
-              <a name="mgmt"></a>
         <h3>B4.042</h3>
         <ul>
           <li>Tuesday, February 7
             <ul>
               <li>14:00 - Next Generation Config Mgmt: Workshop - James Shubin </li>
+              <a name="puppet"></a>
               <li>14:40 - Next Generation Config Mgmt: Workshop - James Shubin </li>
               <li>15:20 - Break</li>
               <li>15:40 - Puppet and mgmt - better together - Felix Frank</li>
@@ -320,7 +333,6 @@
         </ul>
 
         <h2>Puppet</h2>
-              <a name="puppet"></a>
         <h3>B1.015</h3>
         <ul>
           <li>
@@ -338,6 +350,7 @@
           <li>Tuesday, February 7
             <ul>
               <li>14:00 - Dr. Restless or how I stopped worrying about not having proper infrastructure docs at hand! - Felix Kronlage</li>
+              <a name="rudder"></a>
               <li>14:40 - Puppet control-repo to the next level - Alessandro Franceschi</li>
               <li>15:20 - Break</li>
               <li>15:40 - Knee deep in the undef: Tales from refactoring old Puppet codebases - Peter Souter</li>
@@ -346,7 +359,6 @@
         </ul>
 
         <h2>Rudder</h2>
-              <a name="rudder"></a>
         <h3>B4.042</h3>
         <p>
           The following talks will happen in the Rudder Community room (B4.042).
@@ -381,16 +393,6 @@
             </ul>
           </li>
         </ul>
-
-        <h2>Kubernetes</h2>
-        <h3>B3.039</h3>
-        <ul>
-          <li>
-            Tuesday, February 7
-            <ul>
-              <li>14:00 - Kubernetes Hackathon and Lightning Talks </li>
-            </ul>
-          </li>
 
         <h1>Fringe Events - Wednesday, February 8</h1>
         <p>


### PR DESCRIPTION
I know this doesn't seem to make any sense.  Why does
`<a name="chef"></a>` appear in the middle of the CFEngine talks?!

Well, it's to account for the header on the page so when you click the
"chef" link at the top of the page your browser jumps down to the Chef
section of the page, not just past it.

Signed-off-by: Nathen Harvey <nharvey@chef.io>