### PR TITLE
Should we include fringe day in the date span?

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,7 +43,7 @@
         <div class="inner">
           <h1>Config Management Camp</h1>
           <div class="camp-info">
-            <h2><strong>5th &amp; 6th February, 2018</strong></h2>
+            <h2><strong>5 - 7 February, 2018</strong></h2>
             <h2>Gent, Belgium</h2>
           </div>
         </div>
@@ -90,6 +90,7 @@
       <section id="news">
          <h1>News</h1>
            <p>
+<<<<<<< HEAD
              After 6 successful events, 4 in Gent, 1 in Berlin, and 1 in
              Portland, OR, Configuration Management Camp is hosting it's 5th
              year anniversary event.  Configuration Management Camp Gent will be
@@ -97,6 +98,10 @@
              scheduled for the 7th.  Want to host a fringe event?  Get in touch
              with the conference organizers at
              <a href="mailto:info@cfgmgmtcamp.eu">info@cfgmgmtcamp.eu</a>.
+=======
+           After 6 successful events, 4 in Gent, 1 in Berlin, and 1 in Portland OR,  Config Management Camp is hosting it's 5th year anniversary event.
+           We have got confirmation on the dates.  Config Management Camp Gent will run again on the 5 and 6 of February 2018
+>>>>>>> Should we include fringe day in the date span?
            </p>
 
            <p>

--- a/index.html
+++ b/index.html
@@ -90,7 +90,6 @@
       <section id="news">
          <h1>News</h1>
            <p>
-<<<<<<< HEAD
              After 6 successful events, 4 in Gent, 1 in Berlin, and 1 in
              Portland, OR, Configuration Management Camp is hosting it's 5th
              year anniversary event.  Configuration Management Camp Gent will be
@@ -98,10 +97,6 @@
              scheduled for the 7th.  Want to host a fringe event?  Get in touch
              with the conference organizers at
              <a href="mailto:info@cfgmgmtcamp.eu">info@cfgmgmtcamp.eu</a>.
-=======
-           After 6 successful events, 4 in Gent, 1 in Berlin, and 1 in Portland OR,  Config Management Camp is hosting it's 5th year anniversary event.
-           We have got confirmation on the dates.  Config Management Camp Gent will run again on the 5 and 6 of February 2018
->>>>>>> Should we include fringe day in the date span?
            </p>
 
            <p>


### PR DESCRIPTION
This is a question that I'd like to run by the group.  Should we list the primary dates on the site inclusive of the fringe day to encourage people to stay?  What do you think?

Signed-off-by: Nathen Harvey <nharvey@chef.io>