### PR TITLE
Website updates for Puppet fringe and typos

### DIFF
--- a/fringe.html
+++ b/fringe.html
@@ -67,7 +67,7 @@
           <ul>
             <li><a href="#foreman">Foreman Construction Day</a></li>
             <a name="foreman"></a>
-            <li><a href="#puppet">Puppet Contributors Summit</a></li>
+            <li><a href="#puppet">#puppethack day</a></li>
             <li><a href="#habitat">Habitat &amp; InSpec Hackday</a></li>
             <li><a href="#mgmt">Mgmt Hackathon</a></li>
           </ul>
@@ -104,47 +104,37 @@
           see you there!
         </p>
 
-        <h2>Puppet Contributors Summit</h2>
+        <h2>#puppethack</h2>
         <h3>Wednesday, February 7, 10:00 - 16:30, Room TBD</h3>
 
         <p>
-          Puppet Labs is holding our fifth Puppet Contributors Summit in Ghent,
-          Belgium on February 7th, 2018, the day after Config Management Camp.
-          This event is for both existing and new contributors to Puppet,
-          related projects, and modules, and we would love to see the following
-          people attend the Contributors Summit!
+          Puppet is having a community hack event the day after Config Management Camp.
+          This event is for both existing and new contributors to Puppet's open source 
+          codebases like Puppet, Bolt, and Facter; Puppet modules; and related projects.
+          Anyone is welcome, and we'd especially love to see:
           <ul>
             <li>
-              People who submit pull requests and contribute code to our
-              projects
+              People who submit pull requests and contribute code to our projects
             </li>
             <li>
-              Community members working on related projects
+              Community members working on related projects and integrations like testkitchen and Foreman
             </li>
             <li>
-              People who contribute to Puppet Labs modules or contribute their
-              own modules to the Puppet Forge
+              People who contribute to Vox Pupuli modules or publish their own modules to the Puppet Forge
             </li>
             <li>
-              Key community members who answer a lot of questions about using
-              Puppet
-            </li>
-            <a name="habitat"></a>
-            <li>
-              Long-time Puppet users who are interested in doing more
+              Long-time Puppet users who are interested in learning more about new tech like Puppet Tasks and Hiera 5
             </li>
           </ul>
         </p>
-
+        <a name="habitat"></a>
         <p>
-          Learn more about the Puppet Contributor Summit and other contributor
-          events.  All attendees at Puppet Labs events (speakers and
-          participants) should adhere to our Community Guidelines and Event Code
+          All attendees at Puppet events must adhere to our Community Guidelines and Event Code
           of Conduct.  Register:
           <a href="https://contributor-summit-eu-2017.eventbrite.com">Here</a>
         </p>
 
-        <h2>Habitat &amp; InSpec Hackday</h2>
+        <h2>Habitat &amp; InSpec Hackday</a></h2>
         <h3>Wednesday, February 7, 10:00 - 16:30, Room TBD</h3>
 
         <p>

--- a/fringe.html
+++ b/fringe.html
@@ -134,7 +134,7 @@
           <a href="https://contributor-summit-eu-2017.eventbrite.com">Here</a>
         </p>
 
-        <h2>Habitat &amp; InSpec Hackday</a></h2>
+        <h2>Habitat &amp; InSpec Hackday</h2>
         <h3>Wednesday, February 7, 10:00 - 16:30, Room TBD</h3>
 
         <p>

--- a/index.html
+++ b/index.html
@@ -94,8 +94,8 @@
              Stay in Gent an extra day for some time and space to explore topics
              and technologies discussed during the main conference.  This year's
              Fringe events include a <a href="fringe.html#foreman">Foreman
-             Construction Day</a>, a <a href="fringe.html#puppet">Puppet
-             Contributors' Summit</a>, and Hackdays for
+             Construction Day</a>, a <a href="fringe.html#puppet">#puppethack event 
+             </a>, and Hackdays for
              <a href="fringe.html#habitat">Habitat</a>,
              <a href="fringe.html#habitat">InSpec</a>, and
              <a href="fringe.html#mgmt">Mgmt</a>.  <a href="fringe.html">Read
@@ -103,7 +103,7 @@
            </p>
            <p>
              After 6 successful events, 4 in Gent, 1 in Berlin, and 1 in
-             Portland, OR, Configuration Management Camp is hosting it's 5th
+             Portland, OR, Configuration Management Camp is hosting its 5th
              year anniversary event.  Configuration Management Camp Gent will be
              held on the 5th and 6th of February 2018 with fringe events
              scheduled for the 7th.  Want to host a fringe event?  Get in touch
@@ -151,13 +151,13 @@
               <p style="text-align:center;line-height:200px;">
                 <a href="https://www.chef.io/"><img src="http://cfgmgmtcamp.eu/images/Chef_Vertical_Website_IO_Reg.png" alt="Chef" width="284" height="300"></a><span style="padding:50px">&nbsp;</span>
               </p>
-            <h2>Platinium</h2>
+            <h2>Platinum</h2>
               <p style="text-align:center;line-height:150px;">
                 <a href="http://redhat.com/"><img src="http://cfgmgmtcamp.eu/images/redhat-logo1.jpg" height="125" style="PADDING-LEFT: 15px"></a>
               </p>
             <h2>Gold</h2>
               <p style="text-align:center;line-height:100px;">
-                <a href="http://puppetlabs.com"><img src="http://cfgmgmtcamp.eu/images/Puppet-Logo-Amber-sm.jpg" alt="Puppet" width="250" height="100"></a><span style="padding:50px">&nbsp;</span>
+                <a href="http://puppet.com"><img src="http://cfgmgmtcamp.eu/images/Puppet-Logo-Amber-sm.jpg" alt="Puppet" width="250" height="100"></a><span style="padding:50px">&nbsp;</span>
                 <a href="http://www.example42.com/"><img src="http://cfgmgmtcamp.eu/images/example42.png" alt="example42" width="169" height="100"></a><span style="padding:50px">&nbsp;</span>
                 <a href="http://www.normation.com"><img src="http://cfgmgmtcamp.eu/images/rudder.png" alt="Rudder" width="330" height="100"></a><span style="padding:50px">&nbsp;</span>
 


### PR DESCRIPTION
- A couple of typos in index.html
- renamed 'puppet labs' to 'puppet'
- updated description of puppet fringe event since it's not
actually a contributor summit anymore.