### PR TITLE
fix 404 on fringe direct event anchors

### DIFF
--- a/schedule/index.html
+++ b/schedule/index.html
@@ -348,13 +348,13 @@
           Configuration Management includes a number of
           <a href="../fringe.html">fringe events on Wednesday, February 7</a>
           <ul>
-            <li><a href="fringe.html#foreman">Foreman Construction Day</a></li>
-            <li><a href="fringe.html#puppet">#puppethack day</a></li>
-            <li><a href="fringe.html#habitat">Habitat &amp; InSpec Hackday</a></li>
-            <li><a href="fringe.html#mgmt">Mgmt Hackathon</a></li>
-            <li><a href="fringe.html#sysdig">Container Troubleshooting Workshop with Sysdig</a></li>
-            <li><a href="fringe.html#cfengine-iot">CFEngine and IoT hackathon</a></li>
-            <li><a href="fringe.html#ansible">Ansible Lightbulb Workshop</a></li>
+            <li><a href="../fringe.html#foreman">Foreman Construction Day</a></li>
+            <li><a href="../fringe.html#puppet">#puppethack day</a></li>
+            <li><a href="../fringe.html#habitat">Habitat &amp; InSpec Hackday</a></li>
+            <li><a href="../fringe.html#mgmt">Mgmt Hackathon</a></li>
+            <li><a href="../fringe.html#sysdig">Container Troubleshooting Workshop with Sysdig</a></li>
+            <li><a href="../fringe.html#cfengine-iot">CFEngine and IoT hackathon</a></li>
+            <li><a href="../fringe.html#ansible">Ansible Lightbulb Workshop</a></li>
           </ul>
         </p>
         <a name="fringe"></a>


### PR DESCRIPTION
links on bottom page to fridge events are in 404:
![image](https://user-images.githubusercontent.com/153505/35620590-df76a92a-0681-11e8-90a1-659fe47ef918.png)
