### PR TITLE
No more social network links ?

### DIFF
--- a/schedule/salt/monitoring.html
+++ b/schedule/salt/monitoring.html
@@ -12,6 +12,7 @@
     <link rel="stylesheet" type="text/css" href="../../stylesheets/pygment_trac.css" media="screen" />
     <link rel="stylesheet" type="text/css" href="../../stylesheets/print.css" media="print" />
     <link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.6.4/leaflet.css" />
+    <link href="https://use.fontawesome.com/releases/v5.0.6/css/all.css" rel="stylesheet">
     <link rel="shortcut icon" href="favicon.ico">
     <!--[if lte IE 8]>
        <link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.6.4/leaflet.ie.css" />
@@ -90,7 +91,7 @@ This talk will involve the following SaltStack components :
   
 Arthur Lutz has been working on agile infrastructures for more than 10 years, the last 5 years the SaltStack toolkit has considerably helped him orchestrate and deploy services for Logilab employees and companies alike. He shares his experience and knowledge by organising the Paris Salt Meetup, the Nantes Monitoring Meetup, and the Nantes Python Meetup. 
   </p>
-<a class="fa fa-twitter-square fa-2x" href="https://twitter.com/"></a><a class="fa fa-github-square fa-2x" href="https://github.com/"></a></p>
+<a class="fa fa-twitter-square fa-2x" href="https://twitter.com/arthurlutz"></a><a class="fa fa-github-square fa-2x" href="https://github.com/arthurlogilab"></a></p>
 </section>
 </div>
     </div>


### PR DESCRIPTION
On viewing current update I see we don't use the end links to github and twitter accounts.

I have added last font-awesome css and fixed speaker information.

I don't know if the first patch is generated (I hope for you) or not but it could be interesting to update the template :)